### PR TITLE
improved parser performance

### DIFF
--- a/src/main/scala/com/komanov/uuid/UuidJavaFinalUtils2.java
+++ b/src/main/scala/com/komanov/uuid/UuidJavaFinalUtils2.java
@@ -1,0 +1,37 @@
+package com.komanov.uuid;
+
+import java.util.UUID;
+
+public class UuidJavaFinalUtils2 {
+
+    public static UUID fromStringFast(String s) {
+        validate(s);
+        final int component3EndIndex = 18;
+        final long mostSigBits = parseHex(s, 0, component3EndIndex);
+        final long leastSigBits = parseHex(s, component3EndIndex + 1, s.length());
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    private static void validate(String s) {
+        if (s.length() != 36) {
+            throw new IllegalArgumentException("Illegal UUID " + s);
+        }
+        if (s.charAt(8) != '-' && s.charAt(13) != '-' && s.charAt(18) != '-' && s.charAt(23) != '-') {
+            throw new IllegalArgumentException("Expected 4 hyphens (-) in a string: " + s);
+        }
+    }
+
+    private static long parseHex(final String s, final int from, final int to) {
+        long result = 0;
+        for (int i = from; i < to; i++) {
+            char ch = s.charAt(i);
+            if (ch == '-') continue;
+            final int digit = Character.digit(ch, 16);
+            if (digit < 0)
+                throw new NumberFormatException(s.substring(from, to));
+            result = result * 16 + digit;
+        }
+
+        return result;
+    }
+}

--- a/src/test/scala/com/komanov/AbstractPerfTestDisruptor.java
+++ b/src/test/scala/com/komanov/AbstractPerfTestDisruptor.java
@@ -1,0 +1,54 @@
+package com.komanov;
+
+public abstract class AbstractPerfTestDisruptor
+{
+    public static final int RUNS = 10;
+    private static final long ITERATIONS = 1000L * 1000L * 200L;
+
+    protected void testImplementations()
+            throws Exception
+    {
+        final int availableProcessors = Runtime.getRuntime().availableProcessors();
+        if (getRequiredProcessorCount() > availableProcessors)
+        {
+            System.out.print("*** Warning ***: your system has insufficient processors to execute the test efficiently. ");
+            System.out.println("Processors required = " + getRequiredProcessorCount() + " available = " + availableProcessors);
+        }
+
+        long[] disruptorOps = new long[RUNS];
+
+        System.out.println("Starting performance tests");
+        for (int i = 0; i < RUNS; i++)
+        {
+            System.gc();
+            disruptorOps[i] = runDisruptorPass();
+            System.out.format("Run %d, Parse UUID=%,d ops/sec%n", i, Long.valueOf(disruptorOps[i]));
+        }
+    }
+
+    public static void printResults(final String className, final long[] disruptorOps, final long[] queueOps)
+    {
+        for (int i = 0; i < RUNS; i++)
+        {
+            System.out.format("%s run %d: BlockingQueue=%,d Disruptor=%,d ops/sec\n",
+                    className, Integer.valueOf(i), Long.valueOf(queueOps[i]), Long.valueOf(disruptorOps[i]));
+        }
+    }
+
+    protected abstract int getRequiredProcessorCount();
+
+    protected long runDisruptorPass() throws InterruptedException
+    {
+        long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            runAlgorithm();
+        }
+        long end = System.currentTimeMillis();
+
+        long opsPerSec = ITERATIONS / (end - start);
+        return opsPerSec;
+    }
+
+
+    protected abstract void runAlgorithm();
+}

--- a/src/test/scala/com/komanov/PerformanceTest.java
+++ b/src/test/scala/com/komanov/PerformanceTest.java
@@ -1,0 +1,20 @@
+package com.komanov;
+
+public class PerformanceTest {
+
+    public static void main(String[] args) throws Exception
+    {
+
+        System.out.println("Fastest Dmitry");
+        UUIDParserPerformanceTest test = new UUIDParserPerformanceTest();
+        test.testImplementations();
+
+
+
+        System.out.println("Fastest Noam");
+        UUIDParserPerformance2Test test2 = new UUIDParserPerformance2Test();
+        test2.testImplementations();
+    }
+
+
+}

--- a/src/test/scala/com/komanov/UUIDParserPerformance2Test.java
+++ b/src/test/scala/com/komanov/UUIDParserPerformance2Test.java
@@ -1,0 +1,20 @@
+package com.komanov;
+
+import com.komanov.uuid.UuidJavaFinalUtils2;
+
+public class UUIDParserPerformance2Test extends AbstractPerfTestDisruptor {
+
+
+    private static final String TestUUID = "01234567-89ab-cdef-ABCD-EF1234567890";
+
+    @Override
+    protected int getRequiredProcessorCount() {
+        return 1;
+    }
+
+
+    @Override
+    protected void runAlgorithm() {
+        UuidJavaFinalUtils2.fromStringFast(TestUUID);
+    }
+}

--- a/src/test/scala/com/komanov/UUIDParserPerformanceTest.java
+++ b/src/test/scala/com/komanov/UUIDParserPerformanceTest.java
@@ -1,0 +1,18 @@
+package com.komanov;
+
+import com.komanov.uuid.UuidJavaFinalUtils;
+
+public class UUIDParserPerformanceTest extends AbstractPerfTestDisruptor {
+
+    private static final String TestUUID = "01234567-89ab-cdef-ABCD-EF1234567890";
+
+    @Override
+    protected int getRequiredProcessorCount() {
+        return 1;
+    }
+
+    @Override
+    protected void runAlgorithm() {
+        UuidJavaFinalUtils.fromStringFast(TestUUID);
+    }
+}

--- a/src/test/scala/com/komanov/uuid/GuidParserPerformanceTest.scala
+++ b/src/test/scala/com/komanov/uuid/GuidParserPerformanceTest.scala
@@ -33,8 +33,9 @@ object GuidParserPerformanceTest extends App {
   val javaFast4F: ParserFunc = UuidJava4Utils.fromStringFast
   val javaFast5F: ParserFunc = UuidJava5Utils.fromStringFast
   val javaFastFF: ParserFunc = UuidJavaFinalUtils.fromStringFast
+  val javaFastFG: ParserFunc = UuidJavaFinalUtils2.fromStringFast
 
-  val algorithms = Seq(originalF, /*scalaFast,F*/ javaFast0F, javaFast1F, javaFast2F, javaFast3F, javaFast4F, javaFast5F, javaFastFF)
+  val algorithms = Seq(originalF, /*scalaFast,F*/ javaFast0F, javaFast1F, javaFast2F, javaFast3F, javaFast4F, javaFast5F, javaFastFF, javaFastFG)
 
   doWarmUp()
   doFuncTest()
@@ -47,7 +48,8 @@ object GuidParserPerformanceTest extends App {
   doTest("java 3  ", javaFast3F)
   doTest("java 4  ", javaFast4F)
   doTest("java 5  ", javaFast5F)
-  doTest("java f  ", javaFast5F)
+  doTest("java f  ", javaFastFF)
+  doTest("java f2  ", javaFastFG)
 
   def doTest(name: String, f: ParserFunc): Unit = {
     Runtime.getRuntime.gc()


### PR DESCRIPTION
Added new algorithm to parse, passes all tests.
Added my own performance test based on disruptor performance tests
Tests results:

Fastest Dmitry
Starting performance tests
Run 0, Parse UUID=5,791 ops/sec
Run 1, Parse UUID=6,069 ops/sec
Run 2, Parse UUID=6,404 ops/sec
Run 3, Parse UUID=6,389 ops/sec
Run 4, Parse UUID=5,332 ops/sec
Run 5, Parse UUID=6,630 ops/sec
Run 6, Parse UUID=6,710 ops/sec
Run 7, Parse UUID=6,629 ops/sec
Run 8, Parse UUID=6,709 ops/sec
Run 9, Parse UUID=6,642 ops/sec
Fastest Noam
Starting performance tests
Run 0, Parse UUID=13,207 ops/sec
Run 1, Parse UUID=13,360 ops/sec
Run 2, Parse UUID=13,307 ops/sec
Run 3, Parse UUID=12,960 ops/sec
Run 4, Parse UUID=13,681 ops/sec
Run 5, Parse UUID=13,606 ops/sec
Run 6, Parse UUID=13,901 ops/sec
Run 7, Parse UUID=14,264 ops/sec
Run 8, Parse UUID=13,059 ops/sec
Run 9, Parse UUID=13,573 ops/sec
